### PR TITLE
Fixing [squid:S2864] [squid:S1066] AND [squid:S1155]

### DIFF
--- a/github/src/main/java/org/arquillian/extension/governor/github/impl/GitHubTestExecutionDecider.java
+++ b/github/src/main/java/org/arquillian/extension/governor/github/impl/GitHubTestExecutionDecider.java
@@ -145,11 +145,9 @@ public class GitHubTestExecutionDecider implements TestExecutionDecider, Governo
     public void on(@Observes AfterSuite event, GitHubGovernorClient githubGovernorClient) {
         for (Map.Entry<Annotation, Boolean> entry : closePassedDecider.get().get().entrySet()) {
             Annotation annotation = entry.getKey();
-            if (annotation.annotationType() == provides()) {
-                if (entry.getValue()) {
-                    String id = ((GitHub) annotation).value();
-                    githubGovernorClient.close(id);
-                }
+            if (annotation.annotationType() == provides() && entry.getValue()) {
+                String id = ((GitHub) annotation).value();
+                githubGovernorClient.close(id);
             }
         }
     }

--- a/ignore/src/main/java/org/arquillian/extension/governor/ignore/IgnoreObserver.java
+++ b/ignore/src/main/java/org/arquillian/extension/governor/ignore/IgnoreObserver.java
@@ -153,9 +153,9 @@ public class IgnoreObserver {
                     set.addAll(Arrays.asList(exp.split(",")));
                 }
 
-                for (String key : properties.keySet()) {
-                    if (key.startsWith(EXTENSION_PROPERTY_METHODS + "_")) {
-                        set.add(properties.get(key));
+                for (Map.Entry<String, String> entry : properties.entrySet()) {
+                    if (entry.getKey().startsWith(EXTENSION_PROPERTY_METHODS + "_")) {
+                        set.add(entry.getValue());
                     }
                 }
             }

--- a/impl/src/main/java/org/arquillian/extension/governor/configuration/GovernorConfiguration.java
+++ b/impl/src/main/java/org/arquillian/extension/governor/configuration/GovernorConfiguration.java
@@ -54,14 +54,11 @@ public class GovernorConfiguration extends Configuration
     @Override
     public void validate() throws GovernorConfigurationException
     {
-        if (getIgnore())
+        if (getIgnore() && getIgnoreOnly() != null && getIgnoreOnly().length() != 0)
         {
-            if (getIgnoreOnly() != null && getIgnoreOnly().length() != 0)
-            {
-                throw new GovernorConfigurationException("You have set 'ignore' property to true and you set 'ignoreOnly' as well. "
-                    + "Either set 'ignore' and left ignoreOnly unset or left 'ignore' flag unset "
-                    + "and set 'ignoreOnly' property.");
-            }
+            throw new GovernorConfigurationException("You have set 'ignore' property to true and you set 'ignoreOnly' as well. "
+                + "Either set 'ignore' and left ignoreOnly unset or left 'ignore' flag unset "
+                + "and set 'ignoreOnly' property.");
         }
     }
 

--- a/impl/src/main/java/org/arquillian/extension/governor/impl/GovernorTestClassScanner.java
+++ b/impl/src/main/java/org/arquillian/extension/governor/impl/GovernorTestClassScanner.java
@@ -167,7 +167,7 @@ public class GovernorTestClassScanner
                 }
             }
 
-            if (methodAnnotations.size() > 0)
+            if (!methodAnnotations.isEmpty())
             {
                 methodAnnotationsMap.put(method, methodAnnotations);
             }

--- a/jira/src/main/java/org/arquillian/extension/governor/jira/impl/JiraTestExecutionDecider.java
+++ b/jira/src/main/java/org/arquillian/extension/governor/jira/impl/JiraTestExecutionDecider.java
@@ -143,11 +143,9 @@ public class JiraTestExecutionDecider implements TestExecutionDecider, GovernorP
     public void on(@Observes AfterSuite event, JiraGovernorClient jiraGovernorClient) {
         for (Map.Entry<Annotation, Boolean> entry : closePassedDecider.get().get().entrySet()) {
             Annotation annotation = entry.getKey();
-            if (annotation.annotationType() == provides()) {
-                if (entry.getValue()) {
-                    String id = ((Jira) annotation).value();
-                    jiraGovernorClient.close(id);
-                }
+            if (annotation.annotationType() == provides() && entry.getValue()) {
+                String id = ((Jira) annotation).value();
+                jiraGovernorClient.close(id);
             }
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 
squid:S1066 - “Collapsible "if" statements should be merged”.
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 

You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Ayman Abdelghany.