### PR TITLE
Updates to give system properties precedence over arquillian.xml

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,8 +8,9 @@ by putting your custom annotations on the test methods.
 The resolution of the test method execution is done during the test class 
 execution in `BeforeClass` phase.
 
-Currenly, there are two implementations which use API of the Arquillian 
-Governor extension - Arquillian JIRA Governor extension and Arquillian Skipper extension.
+Currenly, implementations which use API of the Arquillian
+Governor extension are Arquillian JIRA Governor extension, Arquillian GitHub Governor extension,
+Arquillian Redmine Governor extension and Arquillian Skipper extension.
 
 === Configuration of Arquillian Governor extension
 
@@ -97,11 +98,13 @@ Available properties for `governor-jira` extension:
 
 |===
 
-If you do not specify `server`, `username` or `password` properties in `arquillian.xml` 
-for JIRA Governor, this extension looks for system properties `jira.governor.server`, `jira.governor.username` and 
-`jira.governor.password` respectively.
+The extension looks for `server`, `username` or `password` properties specified as system properties `jira.governor.server`,
+`jira.governor.username` and `jira.governor.password` respectively.
+If system properties are not defined, this extension looks for `server`, `username` or `password` properties in `arquillian.xml`
+for JIRA Governor.
 
 You can also set properties `force` and `closePassed` by system properties `jira.governor.force` and `jira.governor.closepassed`.
+System properties take precedence over those defined in `arquillian.xml`.
 
 === Usage
 
@@ -273,11 +276,14 @@ Possible properties for `governor-github` extension:
 
 |===
 
-If you do not specify `server` and `username` or `password` properties in `arquillian.xml`
-for GitHub Governor, this extension looks for system properties `github.governor.repository`, `github.governor.repositoryuser`, `github.governor.token`, `github.governor.username` and
+
+The extension looks for system properties `github.governor.repository`, `github.governor.repositoryuser`, `github.governor.token`, `github.governor.username` and
 `github.governor.password` respectively.
+If system properties are not defined, this extension looks for `repository`, `repositoryuser`, `token`, `username` or `password` properties in `arquillian.xml`
+for GitHub Governor.
 
 You can also set properties `force` and `closePassed` by system properties `github.governor.force` and `github.governor.closepassed` by setting them to "true" or "false".
+System properties take precedence over those defined in `arquillian.xml`.
 
 === Usage
 
@@ -440,9 +446,11 @@ Possible properties for `governor-redmine` extension:
 
 |===
 
-If you do not specify `server` and `apikey` properties in `arquillian.xml` for Redmine Governor, this extension looks for system properties `redmine.governor.server` and `redmine.governor.apikey`.
+The extension looks for system properties `redmine.governor.server` and `redmine.governor.apikey`. If system properties are not specified,
+this extension looks for `server` and `apikey` properties in `arquillian.xml` for Redmine Governor,
 
 You can set properties `force`, `closePassed` and `openFailed` by system properties `redmine.governor.force`, `redmine.governor.closepassed` and `redmine.governor.openFailed` by setting them to "true" or "false".
+System properties take precedence over those defined in `arquillian.xml`.
 
 === Usage
 

--- a/api/src/main/java/org/arquillian/extension/governor/api/Configuration.java
+++ b/api/src/main/java/org/arquillian/extension/governor/api/Configuration.java
@@ -86,6 +86,24 @@ public abstract class Configuration {
     }
 
     /**
+     * Gets value of {@code name} property as defined in system variable or return to the {@code getProperty} method to
+     * fetch the value from arquillian.xml
+     *
+     * @param name name of a property you want to get the value of
+     * @param value value of a {@code name} property as defined in system variable or {@code defaultValue} in case it is
+     *              null or empty string
+     * @param defaultValue value returned in case {@code name} is a null string or it is empty
+     * @return value of a {@code name} property as defined in system variable or return to {@code getProperty} if none provided
+     */
+    protected String getSystemProperty(String name, String value, String defaultValue) {
+        if (!value.equals(defaultValue)) {
+            return value;
+        } else {
+            return getProperty(name, defaultValue);
+        }
+    }
+
+    /**
      * Validates configuration.
      *
      * @throws GovernorConfigurationException when configuration of the extension is not valid

--- a/github/src/main/java/org/arquillian/extension/governor/github/configuration/GitHubGovernorConfiguration.java
+++ b/github/src/main/java/org/arquillian/extension/governor/github/configuration/GitHubGovernorConfiguration.java
@@ -44,7 +44,11 @@ public class GitHubGovernorConfiguration extends Configuration {
     private boolean closePassed = resolveClosePassed();
 
     public String getUsername() {
-        return getProperty("username", username);
+        if (!username.equals(EMPTY_STRING)){
+            return username;
+        }else {
+            return getProperty("username", EMPTY_STRING);
+        }
     }
 
     public void setUsername(String username) {
@@ -52,7 +56,11 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getPassword() {
-        return getProperty("password", password);
+        if (!password.equals(EMPTY_STRING)){
+            return password;
+        }else {
+            return getProperty("password", EMPTY_STRING);
+        }
     }
 
     public void setPassword(String password) {
@@ -60,7 +68,11 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getToken() {
-        return getProperty("token", token);
+        if (!token.equals(EMPTY_STRING)){
+            return token;
+        }else {
+            return getProperty("token", EMPTY_STRING);
+        }
     }
 
     public void setToken(String token) {
@@ -68,7 +80,11 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getRepositoryUser() {
-        return getProperty("repositoryUser", repositoryUser);
+        if (!repositoryUser.equals(EMPTY_STRING)){
+            return repositoryUser;
+        }else {
+            return getProperty("repositoryUser", EMPTY_STRING);
+        }
     }
 
     public void setRepositoryUser(String repositoryUser) {
@@ -76,7 +92,11 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getRepository() {
-        return getProperty("repository", repository);
+        if (!repository.equals(EMPTY_STRING)){
+            return repository;
+        }else {
+            return getProperty("repository", EMPTY_STRING);
+        }
     }
 
     public void setRepository(String repository) {
@@ -84,7 +104,11 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
+        if (force == true){
+            return force;
+        }else {
+            return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
+        }
     }
 
     public void setForce(boolean force) {
@@ -92,9 +116,12 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
+        if (closePassed == true) {
+            return closePassed;
+        } else {
+            return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
+        }
     }
-
     public void setClosePassed(boolean closePassed) {
         setProperty("closePassed", Boolean.toString(closePassed));
     }

--- a/github/src/main/java/org/arquillian/extension/governor/github/configuration/GitHubGovernorConfiguration.java
+++ b/github/src/main/java/org/arquillian/extension/governor/github/configuration/GitHubGovernorConfiguration.java
@@ -44,9 +44,9 @@ public class GitHubGovernorConfiguration extends Configuration {
     private boolean closePassed = resolveClosePassed();
 
     public String getUsername() {
-        if (!username.equals(EMPTY_STRING)){
+        if (!username.equals(EMPTY_STRING)) {
             return username;
-        }else {
+        } else {
             return getProperty("username", EMPTY_STRING);
         }
     }
@@ -56,9 +56,9 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getPassword() {
-        if (!password.equals(EMPTY_STRING)){
+        if (!password.equals(EMPTY_STRING)) {
             return password;
-        }else {
+        } else {
             return getProperty("password", EMPTY_STRING);
         }
     }
@@ -68,9 +68,9 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getToken() {
-        if (!token.equals(EMPTY_STRING)){
+        if (!token.equals(EMPTY_STRING)) {
             return token;
-        }else {
+        } else {
             return getProperty("token", EMPTY_STRING);
         }
     }
@@ -80,9 +80,9 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getRepositoryUser() {
-        if (!repositoryUser.equals(EMPTY_STRING)){
+        if (!repositoryUser.equals(EMPTY_STRING)) {
             return repositoryUser;
-        }else {
+        } else {
             return getProperty("repositoryUser", EMPTY_STRING);
         }
     }
@@ -92,9 +92,9 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getRepository() {
-        if (!repository.equals(EMPTY_STRING)){
+        if (!repository.equals(EMPTY_STRING)) {
             return repository;
-        }else {
+        } else {
             return getProperty("repository", EMPTY_STRING);
         }
     }
@@ -104,9 +104,9 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        if (force == true){
+        if (force) {
             return force;
-        }else {
+        } else {
             return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
         }
     }
@@ -116,7 +116,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        if (closePassed == true) {
+        if (closePassed) {
             return closePassed;
         } else {
             return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));

--- a/github/src/main/java/org/arquillian/extension/governor/github/configuration/GitHubGovernorConfiguration.java
+++ b/github/src/main/java/org/arquillian/extension/governor/github/configuration/GitHubGovernorConfiguration.java
@@ -44,11 +44,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     private boolean closePassed = resolveClosePassed();
 
     public String getUsername() {
-        if (!username.equals(EMPTY_STRING)) {
-            return username;
-        } else {
-            return getProperty("username", EMPTY_STRING);
-        }
+        return resolveSystemProperties(username, "username", EMPTY_STRING);
     }
 
     public void setUsername(String username) {
@@ -56,11 +52,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getPassword() {
-        if (!password.equals(EMPTY_STRING)) {
-            return password;
-        } else {
-            return getProperty("password", EMPTY_STRING);
-        }
+        return resolveSystemProperties(password, "password", EMPTY_STRING);
     }
 
     public void setPassword(String password) {
@@ -68,11 +60,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getToken() {
-        if (!token.equals(EMPTY_STRING)) {
-            return token;
-        } else {
-            return getProperty("token", EMPTY_STRING);
-        }
+        return resolveSystemProperties(token, "token", EMPTY_STRING);
     }
 
     public void setToken(String token) {
@@ -80,11 +68,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getRepositoryUser() {
-        if (!repositoryUser.equals(EMPTY_STRING)) {
-            return repositoryUser;
-        } else {
-            return getProperty("repositoryUser", EMPTY_STRING);
-        }
+        return resolveSystemProperties(repositoryUser, "repositoryUser", EMPTY_STRING);
     }
 
     public void setRepositoryUser(String repositoryUser) {
@@ -92,11 +76,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getRepository() {
-        if (!repository.equals(EMPTY_STRING)) {
-            return repository;
-        } else {
-            return getProperty("repository", EMPTY_STRING);
-        }
+        return resolveSystemProperties(repository, "repository", EMPTY_STRING);
     }
 
     public void setRepository(String repository) {
@@ -104,11 +84,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        if (force) {
-            return force;
-        } else {
-            return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
-        }
+        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(force), "force", "false"));
     }
 
     public void setForce(boolean force) {
@@ -116,12 +92,9 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        if (closePassed) {
-            return closePassed;
-        } else {
-            return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
-        }
+        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(closePassed), "closePassed", "false"));
     }
+
     public void setClosePassed(boolean closePassed) {
         setProperty("closePassed", Boolean.toString(closePassed));
     }
@@ -147,7 +120,6 @@ public class GitHubGovernorConfiguration extends Configuration {
         if (EMPTY_STRING.equals(getRepositoryUser()) || EMPTY_STRING.equals(getRepository())) {
             throw new GovernorConfigurationException("Repository user or repository name are not set - it is an empty String.");
         }
-
     }
 
     @Override
@@ -167,6 +139,13 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     // helpers
+    private String resolveSystemProperties(String property, String propertName, String defaultValue) {
+        if (!property.equals(defaultValue)) {
+            return property;
+        } else {
+            return getProperty(propertName, defaultValue);
+        }
+    }
 
     private String resolvePassword() {
         final String password = System.getProperty("github.governor.password");

--- a/github/src/main/java/org/arquillian/extension/governor/github/configuration/GitHubGovernorConfiguration.java
+++ b/github/src/main/java/org/arquillian/extension/governor/github/configuration/GitHubGovernorConfiguration.java
@@ -44,7 +44,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     private boolean closePassed = resolveClosePassed();
 
     public String getUsername() {
-        return resolveSystemProperties(username, "username", EMPTY_STRING);
+        return getSystemProperty("username", username, EMPTY_STRING);
     }
 
     public void setUsername(String username) {
@@ -52,7 +52,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getPassword() {
-        return resolveSystemProperties(password, "password", EMPTY_STRING);
+        return getSystemProperty("password", password, EMPTY_STRING);
     }
 
     public void setPassword(String password) {
@@ -60,7 +60,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getToken() {
-        return resolveSystemProperties(token, "token", EMPTY_STRING);
+        return getSystemProperty("token", token, EMPTY_STRING);
     }
 
     public void setToken(String token) {
@@ -68,7 +68,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getRepositoryUser() {
-        return resolveSystemProperties(repositoryUser, "repositoryUser", EMPTY_STRING);
+        return getSystemProperty("repositoryUser", repositoryUser, EMPTY_STRING);
     }
 
     public void setRepositoryUser(String repositoryUser) {
@@ -76,7 +76,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public String getRepository() {
-        return resolveSystemProperties(repository, "repository", EMPTY_STRING);
+        return getSystemProperty("repository", repository, EMPTY_STRING);
     }
 
     public void setRepository(String repository) {
@@ -84,7 +84,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(force), "force", "false"));
+        return Boolean.parseBoolean(getSystemProperty("force", Boolean.toString(force), "false"));
     }
 
     public void setForce(boolean force) {
@@ -92,7 +92,7 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(closePassed), "closePassed", "false"));
+        return Boolean.parseBoolean(getSystemProperty("closePassed", Boolean.toString(closePassed), "false"));
     }
 
     public void setClosePassed(boolean closePassed) {
@@ -139,14 +139,6 @@ public class GitHubGovernorConfiguration extends Configuration {
     }
 
     // helpers
-    private String resolveSystemProperties(String property, String propertName, String defaultValue) {
-        if (!property.equals(defaultValue)) {
-            return property;
-        } else {
-            return getProperty(propertName, defaultValue);
-        }
-    }
-
     private String resolvePassword() {
         final String password = System.getProperty("github.governor.password");
 

--- a/jira/src/main/java/org/arquillian/extension/governor/jira/configuration/JiraGovernorConfiguration.java
+++ b/jira/src/main/java/org/arquillian/extension/governor/jira/configuration/JiraGovernorConfiguration.java
@@ -45,9 +45,9 @@ public class JiraGovernorConfiguration extends Configuration {
     private boolean closePassed = resolveClosePassed();
 
     public String getUsername() {
-        if (!username.equals(EMPTY_STRING)){
+        if (!username.equals(EMPTY_STRING)) {
             return username;
-        }else {
+        } else {
             return getProperty("username", EMPTY_STRING);
         }
     }
@@ -57,9 +57,9 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public String getPassword() {
-        if (!password.equals(EMPTY_STRING)){
+        if (!password.equals(EMPTY_STRING)) {
             return password;
-        }else {
+        } else {
             return getProperty("password", EMPTY_STRING);
         }
     }
@@ -69,9 +69,9 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public String getServer() {
-        if (!server.equals(DEFAULT_JIRA_SERVER_ADDRESS)){
+        if (!server.equals(DEFAULT_JIRA_SERVER_ADDRESS)) {
             return server;
-        }else {
+        } else {
             return getProperty("server", DEFAULT_JIRA_SERVER_ADDRESS);
         }
     }
@@ -81,9 +81,9 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        if (force == true){
+        if (force) {
             return force;
-        }else {
+        } else {
             return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
         }
     }
@@ -93,9 +93,9 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        if (closePassed == true){
+        if (closePassed) {
             return closePassed;
-        }else {
+        } else {
             return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
         }
     }

--- a/jira/src/main/java/org/arquillian/extension/governor/jira/configuration/JiraGovernorConfiguration.java
+++ b/jira/src/main/java/org/arquillian/extension/governor/jira/configuration/JiraGovernorConfiguration.java
@@ -45,7 +45,11 @@ public class JiraGovernorConfiguration extends Configuration {
     private boolean closePassed = resolveClosePassed();
 
     public String getUsername() {
-        return getProperty("username", username);
+        if (!username.equals(EMPTY_STRING)){
+            return username;
+        }else {
+            return getProperty("username", EMPTY_STRING);
+        }
     }
 
     public void setUsername(String username) {
@@ -53,7 +57,11 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public String getPassword() {
-        return getProperty("password", password);
+        if (!password.equals(EMPTY_STRING)){
+            return password;
+        }else {
+            return getProperty("password", EMPTY_STRING);
+        }
     }
 
     public void setPassword(String password) {
@@ -61,7 +69,11 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public String getServer() {
-        return getProperty("server", server);
+        if (!server.equals(DEFAULT_JIRA_SERVER_ADDRESS)){
+            return server;
+        }else {
+            return getProperty("server", DEFAULT_JIRA_SERVER_ADDRESS);
+        }
     }
 
     public void setServer(String server) {
@@ -69,7 +81,11 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
+        if (force == true){
+            return force;
+        }else {
+            return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
+        }
     }
 
     public void setForce(boolean force) {
@@ -77,7 +93,11 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
+        if (closePassed == true){
+            return closePassed;
+        }else {
+            return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
+        }
     }
 
     public void setClosePassed(boolean closePassed) {

--- a/jira/src/main/java/org/arquillian/extension/governor/jira/configuration/JiraGovernorConfiguration.java
+++ b/jira/src/main/java/org/arquillian/extension/governor/jira/configuration/JiraGovernorConfiguration.java
@@ -45,11 +45,7 @@ public class JiraGovernorConfiguration extends Configuration {
     private boolean closePassed = resolveClosePassed();
 
     public String getUsername() {
-        if (!username.equals(EMPTY_STRING)) {
-            return username;
-        } else {
-            return getProperty("username", EMPTY_STRING);
-        }
+        return resolveSystemProperties(username, "username", EMPTY_STRING);
     }
 
     public void setUsername(String username) {
@@ -57,11 +53,7 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public String getPassword() {
-        if (!password.equals(EMPTY_STRING)) {
-            return password;
-        } else {
-            return getProperty("password", EMPTY_STRING);
-        }
+        return resolveSystemProperties(password, "password", EMPTY_STRING);
     }
 
     public void setPassword(String password) {
@@ -69,11 +61,7 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public String getServer() {
-        if (!server.equals(DEFAULT_JIRA_SERVER_ADDRESS)) {
-            return server;
-        } else {
-            return getProperty("server", DEFAULT_JIRA_SERVER_ADDRESS);
-        }
+        return resolveSystemProperties(server, "server", DEFAULT_JIRA_SERVER_ADDRESS);
     }
 
     public void setServer(String server) {
@@ -81,11 +69,7 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        if (force) {
-            return force;
-        } else {
-            return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
-        }
+        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(force), "force", "false"));
     }
 
     public void setForce(boolean force) {
@@ -93,11 +77,7 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        if (closePassed) {
-            return closePassed;
-        } else {
-            return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
-        }
+        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(closePassed), "closePassed", "false"));
     }
 
     public void setClosePassed(boolean closePassed) {
@@ -162,6 +142,14 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     // helpers
+
+    private String resolveSystemProperties(String property, String propertName, String defaultValue) {
+        if (!property.equals(defaultValue)) {
+            return property;
+        } else {
+            return getProperty(propertName, defaultValue);
+        }
+    }
 
     private String resolveServer() {
         final String server = System.getProperty("jira.governor.server");

--- a/jira/src/main/java/org/arquillian/extension/governor/jira/configuration/JiraGovernorConfiguration.java
+++ b/jira/src/main/java/org/arquillian/extension/governor/jira/configuration/JiraGovernorConfiguration.java
@@ -45,7 +45,7 @@ public class JiraGovernorConfiguration extends Configuration {
     private boolean closePassed = resolveClosePassed();
 
     public String getUsername() {
-        return resolveSystemProperties(username, "username", EMPTY_STRING);
+        return getSystemProperty("username", username, EMPTY_STRING);
     }
 
     public void setUsername(String username) {
@@ -53,7 +53,7 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public String getPassword() {
-        return resolveSystemProperties(password, "password", EMPTY_STRING);
+        return getSystemProperty("password", password, EMPTY_STRING);
     }
 
     public void setPassword(String password) {
@@ -61,7 +61,7 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public String getServer() {
-        return resolveSystemProperties(server, "server", DEFAULT_JIRA_SERVER_ADDRESS);
+        return getSystemProperty("server", server, DEFAULT_JIRA_SERVER_ADDRESS);
     }
 
     public void setServer(String server) {
@@ -69,7 +69,7 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(force), "force", "false"));
+        return Boolean.parseBoolean(getSystemProperty("force", Boolean.toString(force), "false"));
     }
 
     public void setForce(boolean force) {
@@ -77,7 +77,7 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(closePassed), "closePassed", "false"));
+        return Boolean.parseBoolean(getSystemProperty("closePassed", Boolean.toString(closePassed), "false"));
     }
 
     public void setClosePassed(boolean closePassed) {
@@ -142,14 +142,6 @@ public class JiraGovernorConfiguration extends Configuration {
     }
 
     // helpers
-
-    private String resolveSystemProperties(String property, String propertName, String defaultValue) {
-        if (!property.equals(defaultValue)) {
-            return property;
-        } else {
-            return getProperty(propertName, defaultValue);
-        }
-    }
 
     private String resolveServer() {
         final String server = System.getProperty("jira.governor.server");

--- a/redmine/src/main/java/org/arquillian/extension/governor/redmine/configuration/RedmineGovernorConfiguration.java
+++ b/redmine/src/main/java/org/arquillian/extension/governor/redmine/configuration/RedmineGovernorConfiguration.java
@@ -45,7 +45,7 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public String getApiKey() {
-        return resolveSystemProperties(apiKey, "apikey", EMPTY_STRING);
+        return getSystemProperty("apikey", apiKey, EMPTY_STRING);
     }
 
     public void setApiKey(String apiKey) {
@@ -53,11 +53,11 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public String getCloseOrder() {
-        return resolveSystemProperties(closeOrder, "closeOrder", EMPTY_STRING);
+        return getSystemProperty("closeOrder", closeOrder, EMPTY_STRING);
     }
 
     public String getServer() {
-        return resolveSystemProperties(server, "server", EMPTY_STRING);
+        return getSystemProperty("server", server, EMPTY_STRING);
     }
 
     public void setServer(String server) {
@@ -65,7 +65,7 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(force), "force", "false"));
+        return Boolean.parseBoolean(getSystemProperty(Boolean.toString(force), "force", "false"));
     }
 
     public void setForce(boolean force) {
@@ -73,7 +73,7 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(closePassed), "closePassed", "false"));
+        return Boolean.parseBoolean(getSystemProperty("closePassed", Boolean.toString(closePassed), "false"));
     }
 
     public void setClosePassed(boolean closePassed) {
@@ -81,7 +81,7 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getOpenFailed() {
-        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(openFailed), "openFailed", "false"));
+        return Boolean.parseBoolean(getSystemProperty("openFailed", Boolean.toString(openFailed), "false"));
     }
 
     public void setOpenFailed(boolean openFailed) {
@@ -136,15 +136,6 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     // helpers
-
-    private String resolveSystemProperties(String property, String propertName, String defaultValue) {
-        if (!property.equals(defaultValue)) {
-            return property;
-        } else {
-            return getProperty(propertName, defaultValue);
-        }
-    }
-
     private String resolveApiKey() {
         final String apiKey = System.getProperty("github.governor.apikey");
 

--- a/redmine/src/main/java/org/arquillian/extension/governor/redmine/configuration/RedmineGovernorConfiguration.java
+++ b/redmine/src/main/java/org/arquillian/extension/governor/redmine/configuration/RedmineGovernorConfiguration.java
@@ -45,9 +45,9 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public String getApiKey() {
-        if (!apiKey.equals(EMPTY_STRING)){
+        if (!apiKey.equals(EMPTY_STRING)) {
             return apiKey;
-        }else {
+        } else {
             return getProperty("apikey", EMPTY_STRING);
         }
     }
@@ -57,17 +57,17 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public String getCloseOrder() {
-        if (!closeOrder.equals(EMPTY_STRING)){
+        if (!closeOrder.equals(EMPTY_STRING)) {
             return closeOrder;
-        }else {
+        } else {
             return getProperty("closeOrder", EMPTY_STRING);
         }
     }
 
     public String getServer() {
-        if (!server.equals(EMPTY_STRING)){
+        if (!server.equals(EMPTY_STRING)) {
             return server;
-        }else {
+        } else {
             return getProperty("server", EMPTY_STRING);
         }
     }
@@ -77,9 +77,9 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        if (force == true){
+        if (force) {
             return force;
-        }else {
+        } else {
             return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
         }
     }
@@ -89,9 +89,9 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        if (closePassed == true){
+        if (closePassed) {
             return closePassed;
-        }else {
+        } else {
             return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
         }
     }
@@ -101,9 +101,9 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getOpenFailed() {
-        if (openFailed == true){
+        if (openFailed) {
             return openFailed;
-        }else {
+        } else {
             return Boolean.parseBoolean(getProperty("openFailed", Boolean.toString(openFailed)));
         }
     }

--- a/redmine/src/main/java/org/arquillian/extension/governor/redmine/configuration/RedmineGovernorConfiguration.java
+++ b/redmine/src/main/java/org/arquillian/extension/governor/redmine/configuration/RedmineGovernorConfiguration.java
@@ -45,7 +45,11 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public String getApiKey() {
-        return getProperty("apikey", apiKey);
+        if (!apiKey.equals(EMPTY_STRING)){
+            return apiKey;
+        }else {
+            return getProperty("apikey", EMPTY_STRING);
+        }
     }
 
     public void setApiKey(String apiKey) {
@@ -53,11 +57,19 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public String getCloseOrder() {
-        return getProperty("closeOrder", closeOrder);
+        if (!closeOrder.equals(EMPTY_STRING)){
+            return closeOrder;
+        }else {
+            return getProperty("closeOrder", EMPTY_STRING);
+        }
     }
 
     public String getServer() {
-        return getProperty("server", server);
+        if (!server.equals(EMPTY_STRING)){
+            return server;
+        }else {
+            return getProperty("server", EMPTY_STRING);
+        }
     }
 
     public void setServer(String server) {
@@ -65,7 +77,11 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
+        if (force == true){
+            return force;
+        }else {
+            return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
+        }
     }
 
     public void setForce(boolean force) {
@@ -73,7 +89,11 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
+        if (closePassed == true){
+            return closePassed;
+        }else {
+            return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
+        }
     }
 
     public void setClosePassed(boolean closePassed) {
@@ -81,7 +101,11 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getOpenFailed() {
-        return Boolean.parseBoolean(getProperty("openFailed", Boolean.toString(openFailed)));
+        if (openFailed == true){
+            return openFailed;
+        }else {
+            return Boolean.parseBoolean(getProperty("openFailed", Boolean.toString(openFailed)));
+        }
     }
 
     public void setOpenFailed(boolean openFailed) {

--- a/redmine/src/main/java/org/arquillian/extension/governor/redmine/configuration/RedmineGovernorConfiguration.java
+++ b/redmine/src/main/java/org/arquillian/extension/governor/redmine/configuration/RedmineGovernorConfiguration.java
@@ -45,11 +45,7 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public String getApiKey() {
-        if (!apiKey.equals(EMPTY_STRING)) {
-            return apiKey;
-        } else {
-            return getProperty("apikey", EMPTY_STRING);
-        }
+        return resolveSystemProperties(apiKey, "apikey", EMPTY_STRING);
     }
 
     public void setApiKey(String apiKey) {
@@ -57,19 +53,11 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public String getCloseOrder() {
-        if (!closeOrder.equals(EMPTY_STRING)) {
-            return closeOrder;
-        } else {
-            return getProperty("closeOrder", EMPTY_STRING);
-        }
+        return resolveSystemProperties(closeOrder, "closeOrder", EMPTY_STRING);
     }
 
     public String getServer() {
-        if (!server.equals(EMPTY_STRING)) {
-            return server;
-        } else {
-            return getProperty("server", EMPTY_STRING);
-        }
+        return resolveSystemProperties(server, "server", EMPTY_STRING);
     }
 
     public void setServer(String server) {
@@ -77,11 +65,7 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getForce() {
-        if (force) {
-            return force;
-        } else {
-            return Boolean.parseBoolean(getProperty("force", Boolean.toString(force)));
-        }
+        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(force), "force", "false"));
     }
 
     public void setForce(boolean force) {
@@ -89,11 +73,7 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getClosePassed() {
-        if (closePassed) {
-            return closePassed;
-        } else {
-            return Boolean.parseBoolean(getProperty("closePassed", Boolean.toString(closePassed)));
-        }
+        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(closePassed), "closePassed", "false"));
     }
 
     public void setClosePassed(boolean closePassed) {
@@ -101,11 +81,7 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     public boolean getOpenFailed() {
-        if (openFailed) {
-            return openFailed;
-        } else {
-            return Boolean.parseBoolean(getProperty("openFailed", Boolean.toString(openFailed)));
-        }
+        return Boolean.parseBoolean(resolveSystemProperties(Boolean.toString(openFailed), "openFailed", "false"));
     }
 
     public void setOpenFailed(boolean openFailed) {
@@ -160,6 +136,14 @@ public class RedmineGovernorConfiguration extends Configuration {
     }
 
     // helpers
+
+    private String resolveSystemProperties(String property, String propertName, String defaultValue) {
+        if (!property.equals(defaultValue)) {
+            return property;
+        } else {
+            return getProperty(propertName, defaultValue);
+        }
+    }
 
     private String resolveApiKey() {
         final String apiKey = System.getProperty("github.governor.apikey");


### PR DESCRIPTION
#### Short description of what this resolves:
Whenever properties are provided as environment variables as well as in arquillian.xml , system properties should take precedence over arquillian.xml.

#### Changes proposed in this pull request:
- Updates to Github, Jira and Redmine implementations of Governor extension to provide precedence to system properties.

**Fixes**: #41 

